### PR TITLE
fix requirements for amber-tipped tools

### DIFF
--- a/amber.lua
+++ b/amber.lua
@@ -84,7 +84,7 @@ local function tooltip(name, group)
 	nodecore.register_craft({
 			label = "assemble " .. tool,
 			action = "stackapply",
-			{name = modname.. ":amber"},
+			wield = {name = modname.. ":amber"},
 			consumewield = 1,
 			indexkeys = {wood},
 			nodes = {{match = woodmatch, replace = "air"}},


### PR DESCRIPTION
this change resolved #1 on my server.
In fact, it was not just stone chips, but *anything* that could be used to make amber tools, because the wield condition was not being checked properly.